### PR TITLE
Updates to StackOverflow UI and sendgrid APIs + add quick start to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+__pycache__

--- a/README.md
+++ b/README.md
@@ -8,6 +8,27 @@ A Python script deployed to Heroku that performs automatic logins on stackoverfl
 Moreover, you get notified, via email, if the script goes wrong and you haven’t logged into Stack Overflow for at least _twelve hours_.
 
 ## Step-by-step guide
+
 You may follow the step-by-step guide [here](https://medium.com/coders-do-read/earn-the-fanatic-badge-on-stack-overflow-828d2c46930).
 
 And the second part, with additional improvements, [here](https://medium.com/coders-do-read/fanatic-badge-on-stack-overflow-part-two-email-notification-820f5394f8f0).
+
+Alternatively, you can follow the (less detailed) quick start below.
+
+## Quick start
+
+1. Make sure you have the following dependencies:
+
+  - Python 3.6+ (along with pip)
+
+  - Chrome installed (or another browser of choice, though you will have to edit the script)
+
+  - Python packages (use `pip install` to get): `selenium`, `sendgrid`, `webdriver_manager`, `requests_oauthlib`, `apscheduler`
+
+2. Edit `env_vars.txt` to include your email, password, and display name.
+
+3. Run `source env_vars.txt` and then `python3 stack_overflow_page.py`.
+
+## Troubleshooting
+
+The script can trigger a CAPTCHA from StackOverflow. A human has to resolve this.

--- a/README.md
+++ b/README.md
@@ -19,16 +19,26 @@ Alternatively, you can follow the (less detailed) quick start below.
 
 1. Make sure you have the following dependencies:
 
-  - Python 3.6+ (along with pip)
+    - Python 3.6+ (along with pip)
 
-  - Chrome installed (or another browser of choice, though you will have to edit the script)
+    - Chrome installed (or another browser of choice, though you will have to edit the script)
 
-  - Python packages (use `pip install` to get): `selenium`, `sendgrid`, `webdriver_manager`, `requests_oauthlib`, `apscheduler`
+    - Python packages (use `pip install` to get): `selenium`, `sendgrid`, `webdriver_manager`, `requests_oauthlib`, `apscheduler`, `requests`, `python_http_client`
 
-2. Edit `env_vars.txt` to include your email, password, and display name.
+2. Edit `env_vars.txt` to include your email, password, and display name (and remove `#` to comment out the lines).
 
-3. Run `source env_vars.txt` and then `python3 stack_overflow_page.py`.
+    - WARNING: don't push this to a public repository!
+
+    - If you want to be notified by email when things go wrong, [sign up for sendgrid](https://signup.sendgrid.com/) to get an API key, and add that to `env_vars.txt` as well. This can take some work to set up successfully  .
+
+3. Run `source env_vars.txt` and then `python3 stack_overflow_page.py` to see the script work.
+
+To schedule the script locally, you can run `python3 clock.py`. To schedule it using Heroku, see the full guide on Medium.
 
 ## Troubleshooting
 
 The script can trigger a CAPTCHA from StackOverflow. A human has to resolve this.
+
+StackOverflow sometimes changes their UI, so that the old CSS identifiers don't match anymore. This can cause one of lines in `stack_overflow_page.py` starting with `driver.find_element_by_` to fail. To debug this in Chrome, look for the correct identifier to use instead using the "inspect element" feature in developer tools (Ctrl+Shift+C).
+
+Emails sent by sendgrid can go to spam. If you get errors when sending mail with sendgrid, make sure that you have an account which includes an API key, a verified email address, and that you have set up a verified sender to send mail. Note that sendgrid requires the dependency `python-http-client`.

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ Alternatively, you can follow the (less detailed) quick start below.
 
     - WARNING: don't push this to a public repository!
 
-    - If you want to be notified by email when things go wrong, [sign up for sendgrid](https://signup.sendgrid.com/) to get an API key, and add that to `env_vars.txt` as well. This can take some work to set up successfully  .
-
 3. Run `source env_vars.txt` and then `python3 stack_overflow_page.py` to see the script work.
 
-To schedule the script locally, you can run `python3 clock.py`. To schedule it using Heroku, see the full guide on Medium.
+4. If you want to be notified by email when things go wrong, [sign up for sendgrid](https://signup.sendgrid.com/) to get an API key, and add that to `env_vars.txt` as well. This can take some work to set up successfully.
+
+5. To schedule the script on Heroku, sign up for an account on Heroku and follow the instructions in the full step-by-step guide on Medium.
 
 ## Troubleshooting
 

--- a/env_vars.txt
+++ b/env_vars.txt
@@ -1,0 +1,3 @@
+export STACK_OVERFLOW_EMAIL='your.email@example.com'
+export STACK_OVERFLOW_PASSWORD='your.password'
+export STACK_OVERFLOW_DISPLAY_NAME='your.display.name'

--- a/env_vars.txt
+++ b/env_vars.txt
@@ -1,4 +1,10 @@
+## Basic login script:
 # export STACK_OVERFLOW_EMAIL='your.email@example.com'
 # export STACK_OVERFLOW_PASSWORD='your.password'
 # export STACK_OVERFLOW_DISPLAY_NAME='your.display.name'
+## Sendgrid: for sending mail when things go wrong:
 # export SENDGRID_API_KEY='your.api.key'
+## Stack Exchange API: to get an email after a period of inactivity:
+# export STACK_EXCHANGE_CLIENT_ID='1***1'
+# export STACK_EXCHANGE_KEY='**********************(('
+# export STACK_EXCHANGE_ACCESS_TOKEN='*********************Q))'

--- a/env_vars.txt
+++ b/env_vars.txt
@@ -1,3 +1,4 @@
-export STACK_OVERFLOW_EMAIL='your.email@example.com'
-export STACK_OVERFLOW_PASSWORD='your.password'
-export STACK_OVERFLOW_DISPLAY_NAME='your.display.name'
+# export STACK_OVERFLOW_EMAIL='your.email@example.com'
+# export STACK_OVERFLOW_PASSWORD='your.password'
+# export STACK_OVERFLOW_DISPLAY_NAME='your.display.name'
+# export SENDGRID_API_KEY='your.api.key'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-APScheduler==3.0.0
+APScheduler==3.6.3
 requests==2.20.0
-selenium==3.8.1
-sendgrid==5.3.0
-requests_oauthlib==0.8.0
+selenium==3.141.1
+sendgrid==6.3.1
+requests_oauthlib==1.3.0
+webdriver_manager==3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 APScheduler==3.6.3
 requests==2.20.0
-selenium==3.141.1
+selenium==3.8.1
 sendgrid==6.3.1
 requests_oauthlib==1.3.0
 webdriver_manager==3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ selenium==3.141.1
 sendgrid==6.3.1
 requests_oauthlib==1.3.0
 webdriver_manager==3.1.0
+python-http-client==3.2.7

--- a/sendgrid_helper.py
+++ b/sendgrid_helper.py
@@ -10,12 +10,15 @@ def send_mail(subject, content):
         logging.warning("Skipped sending mail... Set 'SENDGRID_API_KEY' env variable to send mail")
         return
 
-    sg = sendgrid.SendGridAPIClient(apikey=os.environ.get('SENDGRID_API_KEY'))
-    from_email = Email("heroku-stackoverflow-fanatic-badge@heroku.com")
-    to_email = Email(os.environ.get('STACK_OVERFLOW_EMAIL'))
-    content = Content("text/plain", content)
-    body = Mail(from_email, subject, to_email, content)
-    response = sg.client.mail.send.post(request_body=body.get())
+    message = Mail(
+        from_email=os.environ.get('STACK_OVERFLOW_EMAIL'),
+        to_emails=os.environ.get('STACK_OVERFLOW_EMAIL'),
+        subject=subject,
+        html_content=content
+    )
+
+    sg = sendgrid.SendGridAPIClient(os.environ.get('SENDGRID_API_KEY'))
+    response = sg.send(message)
 
     logging.debug(response.status_code)
     logging.debug(response.body)

--- a/stack_overflow_page.py
+++ b/stack_overflow_page.py
@@ -43,8 +43,6 @@ def login():
     except Exception as e:
         message = "An error occurred while trying to access stackoverflow.com!"
         logging.error(message, e)
-        logging.error("Opening PDB to debug error")
-        import pdb; pdb.set_trace()
         send_mail("Error at login!", message + str(e))
 
     finally:

--- a/stack_overflow_page.py
+++ b/stack_overflow_page.py
@@ -4,6 +4,7 @@ import os
 
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
+from webdriver_manager.chrome import ChromeDriverManager
 
 from sendgrid_helper import send_mail
 
@@ -22,9 +23,7 @@ def login():
                       "variables to successfully log into Stack Overflow")
         return
 
-    chrome_options = Options()
-    chrome_options.binary_location = os.environ.get('GOOGLE_CHROME_SHIM')
-    driver = webdriver.Chrome(chrome_options=chrome_options)
+    driver = webdriver.Chrome(ChromeDriverManager().install())
 
     try:
         driver.get("https://stackoverflow.com")
@@ -37,13 +36,15 @@ def login():
 
         driver.find_element_by_class_name("my-profile").click()
 
-        elem = driver.find_element_by_class_name("mini-avatar")
+        elem = driver.find_element_by_class_name("grid--cell.ws-nowrap.fs-body3")
         assert display_name in elem.text
         logging.info("Logged into stackoverflow.com and accessed profile page.")
 
     except Exception as e:
         message = "An error occurred while trying to access stackoverflow.com!"
         logging.error(message, e)
+        logging.error("Opening PDB to debug error")
+        import pdb; pdb.set_trace()
         send_mail("Error at login!", message + str(e))
 
     finally:


### PR DESCRIPTION
Fixes:

- Respond to recent changes in StackOverflow's CSS identifiers: replace the line `driver.find_element_by_class_name("mini-avatar")` with `driver.find_element_by_class_name("grid--cell.ws-nowrap.fs-body3")` -- closes https://github.com/alexsomai/stackoverflow-fanatic-badge/issues/10

- Update sendgrid `send_mail` wrapper to use the current API

Enhancements:

- Use `webdriver_manager` to get driver manager for Chrome, so that downloading manually is no longer necessary and doesn't raise compatibility errors-- see https://github.com/alexsomai/stackoverflow-fanatic-badge/issues/10

- Add a quick start guide to README as well as some troubleshooting info

- Bring dependencies in `requirements.txt` up to date

- Add `env_vars.txt` for easy editing / reference

- Add `__pycache__` to `.gitignore`

